### PR TITLE
Renamed "label" to "badge"

### DIFF
--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -596,16 +596,16 @@ Insert custom HTML into the option with the `data-content` attribute:
 
 <div class="bs-docs-example">
   <select class="selectpicker">
-    <option data-content="<span class='label label-warning'>Mustard</span>">Mustard</option>
-    <option data-content="<span class='label label-danger label-important'>Ketchup</span>">Ketchup</option>
-    <option data-content="<span class='label label-success'>Relish</span>">Relish</option>
-    <option data-content="<span class='label label-info'>Mayonnaise</span>">Mayonnaise</option>
+    <option data-content="<span class='badge badge-warning'>Mustard</span>">Mustard</option>
+    <option data-content="<span class='badge badge-danger'>Ketchup</span>">Ketchup</option>
+    <option data-content="<span class='badge badge-success'>Relish</span>">Relish</option>
+    <option data-content="<span class='badge badge-info'>Mayonnaise</span>">Mayonnaise</option>
   </select>
 </div>
 
 ```html
 <select class="selectpicker">
-  <option data-content="<span class='label label-success'>Relish</span>">Relish</option>
+  <option data-content="<span class='label badge-success'>Relish</span>">Relish</option>
 </select>
 ```
 


### PR DESCRIPTION
"Custom content" demo was not working. As per bootstrap 4 docs (https://getbootstrap.com/docs/4.1/migration/#labels-and-badges) labels are now badges.